### PR TITLE
User Story 36 complete with testing

### DIFF
--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -5,7 +5,13 @@ class Admin::InvoicesController < ApplicationController
   end
 
   def show
-    @invoice = Invoice.find(params[:id])
+    @invoice = Invoice.find(params[:invoice_id])
+  end
+
+  def update 
+    @invoice = Invoice.find(params[:invoice_id])
+    @invoice.update! status:Invoice.statuses[params[:invoice_status]]
+    redirect_to "/admin/invoices/#{@invoice.id}"
   end
 end
  

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -1,1 +1,15 @@
-<%="Invoice ID: #{@invoice.id}, Invoice Status: #{@invoice.status}, Invoice Created date: #{@invoice.created_at}, Customer Name: #{@invoice.customer.first_name} #{@invoice.customer.last_name}"%>
+<p><%="Invoice ID: #{@invoice.id}"%></p> 
+
+<div id="update_invoice_status">
+
+  <%=form_with url: "/admin/invoices/#{@invoice.id}", method: :patch, local:true do |f|%>
+   <p>Invoice Status: <%= select_tag "invoice_status", options_for_select([Invoice.statuses.keys[0], Invoice.statuses.keys[1], Invoice.statuses.keys[2]], @invoice.status)%></p>  
+   <%=f.submit "Update Invoice Status"%>
+  <%end%>
+
+
+</div>
+
+<p><%="Invoice Created date: #{@invoice.created_at}"%></p>  
+<p><%="Customer Name: #{@invoice.customer.first_name} #{@invoice.customer.last_name}"%></p>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ namespace :admin do
   get '/merchants/:id', to: 'merchants#show'
   get '/merchants/:id/edit', to: "merchants#edit"
   patch '/merchants/:id', to: "merchants#update"
+  patch '/invoices/:invoice_id', to: "invoices#update"
   # get "/invoices", to: "invoices#index"
   # get "/invoices/:invoice_id", to: "invoices#show"
   # resources :invoices, only: [:index, :show, :update]

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -23,11 +23,51 @@ end
 
   describe "as an admin" do 
     describe "visit admin show page" do 
-      it "shows teh invoice id, invoice status, created at, and customer first and last name" do 
+
+      it "shows the invoice status is a select field (drop down) with the various enum statuses as the options" do   
+        visit "/admin/invoices/#{@invoice_1.id}"
+
+        expect(page).to have_selector("select[name='invoice_status']")
+        expect(page).to have_select('invoice_status', with_options: [Invoice.statuses.keys[0], Invoice.statuses.keys[1], Invoice.statuses.keys[2]])
+      
+      end 
+
+      it "the select field starts out filled out to the current status of the invoice" do
 
         visit "/admin/invoices/#{@invoice_1.id}"
 
-        expect(page).to have_content("Invoice ID: #{@invoice_1.id}, Invoice Status: #{@invoice_1.status}, Invoice Created date: #{@invoice_1.created_at}, Customer Name: #{@invoice_1.customer.first_name} #{@invoice_1.customer.last_name}")
+        expect(page).to have_select('invoice_status', selected: 'in progress')
+      end
+
+      it "next to the select field there is a button to 'Update Invoice Status'" do 
+        visit "/admin/invoices/#{@invoice_1.id}"
+
+        within("div#update_invoice_status") do 
+          expect(page).to have_button("Update Invoice Status")
+        end 
+      end 
+      
+      it "when you select a different options from the drop down and click the update invoice status button, you return to the invoice show page and the invoice status has changed" do 
+
+      visit "/admin/invoices/#{@invoice_1.id}"
+        expect(page).to have_select('invoice_status', selected: 'in progress')
+
+        select Invoice.statuses.keys[2], from: "invoice_status"
+
+        click_button("Update Invoice Status")
+        save_and_open_page
+        expect(page).to have_select('invoice_status', selected: 'cancelled')
+
+        expect(current_path).to eq("/admin/invoices/#{@invoice_1.id}")
+      end
+
+      it "shows teh invoice id, invoice status, created at, and customer first and last name" do 
+
+        visit "/admin/invoices/#{@invoice_1.id}"
+        expect(page).to have_content("Invoice ID: #{@invoice_1.id}") 
+        expect(page).to have_content("Invoice Status: #{@invoice_1.status}")
+        expect(page).to have_content("Invoice Created date: #{@invoice_1.created_at}") 
+        expect(page).to have_content("Customer Name: #{@invoice_1.customer.first_name} #{@invoice_1.customer.last_name}")
 
 
       end


### PR DESCRIPTION
36. Admin Invoice Show Page: Update Invoice Status

As an admin     
When I visit an admin invoice show page
I see the invoice status is a select field
And I see that the invoice's current status is selected
When I click this select field,
Then I can select a new status for the Invoice,
And next to the select field I see a button to "Update Invoice Status"
When I click this button
I am taken back to the admin invoice show page
And I see that my Invoice's status has now been updated

Complete with tests. 