### PR TITLE
Userstory31

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -24,4 +24,8 @@ class Invoice < ApplicationRecord
     .group(:id)
     .order(:created_at)
   end
+
+  def format_date
+    created_at.strftime("%F")
+  end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -31,11 +31,22 @@ class Merchant < ApplicationRecord
     .order('total_revenue desc')
     .limit(5)
   end
-  
+
   def total_revenue
     self.invoices
     .joins(:invoice_items, :transactions)
     .where('transactions.result = 0')
     .sum('invoice_items.quantity * invoice_items.unit_price')
+  end
+
+  def top_selling_date
+    self.invoices
+    .where("invoices.status = 1")
+    .joins(:invoice_items)
+    .select('invoices.id, invoices.created_at, sum(invoice_items.unit_price * invoice_items.quantity) as total_revenue')
+    .group("invoices.id, invoices.created_at")
+    .order("total_revenue desc", "invoices.created_at desc")
+    .limit(1)
+    .first
   end
 end

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -7,6 +7,8 @@
     <%= link_to merchant.name, "/admin/merchants/#{merchant.id}", local: true  %>
     <%= "Revenue Earned: $#{merchant.total_revenue / 100}" %>
     <br>
+    <%= "Top selling date for #{merchant.name}: #{merchant.top_selling_date.format_date}" %>
+    <br>
   <% end %>
 </div>
   

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe "admin merchants index" do
 
     @customer1 = Customer.create!(first_name: "Steve", last_name: "Stevinson")
 
-    @invoice1 = Invoice.create!(customer: @customer1, status: 1) #completed
-    @invoice2 = Invoice.create!(customer: @customer1, status: 1) #completed
-    @invoice3 = Invoice.create!(customer: @customer1, status: 1) #completed
+    @invoice1 = Invoice.create!(customer: @customer1, status: 1, created_at: "01/01/2023".to_date) #completed
+    @invoice2 = Invoice.create!(customer: @customer1, status: 1, created_at: "02/02/2023".to_date) #completed
+    @invoice3 = Invoice.create!(customer: @customer1, status: 1, created_at: "10/02/2022".to_date) #completed
     @invoice4 = Invoice.create!(customer: @customer1, status: 1) #completed
     @invoice5 = Invoice.create!(customer: @customer1, status: 1) #completed
     @invoice6 = Invoice.create!(customer: @customer1, status: 1) #completed
@@ -119,5 +119,18 @@ RSpec.describe "admin merchants index" do
         expect(page).to have_content("#{@merchant5.total_revenue / 100}")
       end
     end
+
+    it 'displays the best day the merchant had in sales' do
+      visit '/admin/merchants'
+
+      within "#top_5_merchants" do
+        expect(page).to have_content("Top selling date for #{@merchant1.name}: #{@merchant1.top_selling_date.format_date}")
+        expect(page).to have_content("Top selling date for #{@merchant2.name}: #{@merchant2.top_selling_date.format_date}")
+        expect(page).to have_content("Top selling date for #{@merchant3.name}: #{@merchant3.top_selling_date.format_date}")
+        expect(page).to have_content("Top selling date for #{@merchant4.name}: #{@merchant4.top_selling_date.format_date}")
+        expect(page).to have_content("Top selling date for #{@merchant5.name}: #{@merchant5.top_selling_date.format_date}")
+      end
+    end
   end
+
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -101,6 +101,13 @@ RSpec.describe Invoice, type: :model do
         expect(@invoice_1.total_revenue).to eq(67)
       end
     end
+
+    describe '#format_date' do
+      it 'returns the date of the invoice in yyyy/mm/dd format' do
+        @invoice_1.created_at = "Mon, 27 Feb 2023 22:51:42 UTC +00:00"
+        expect(@invoice_1.format_date).to eq("2023-02-27")
+      end
+    end
   end
 
   describe "class method" do

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -149,9 +149,9 @@ RSpec.describe Merchant, type: :model do
 
         @customer1 = Customer.create!(first_name: "Steve", last_name: "Stevinson")
 
-        @invoice1 = Invoice.create!(customer: @customer1, status: 1) #completed
-        @invoice2 = Invoice.create!(customer: @customer1, status: 1) #completed
-        @invoice3 = Invoice.create!(customer: @customer1, status: 1) #completed
+        @invoice1 = Invoice.create!(customer: @customer1, status: 1, created_at: "01/01/2023".to_date) #completed
+        @invoice2 = Invoice.create!(customer: @customer1, status: 1, created_at: "02/02/2023".to_date) #completed
+        @invoice3 = Invoice.create!(customer: @customer1, status: 1, created_at: "10/02/2022".to_date) #completed
         @invoice4 = Invoice.create!(customer: @customer1, status: 1) #completed
         @invoice5 = Invoice.create!(customer: @customer1, status: 1) #completed
         @invoice6 = Invoice.create!(customer: @customer1, status: 1) #completed
@@ -190,6 +190,12 @@ RSpec.describe Merchant, type: :model do
 
       it 'shows the total revenue' do
         expect(@merchant1.total_revenue).to eq(2400)
+      end
+
+      it 'shows the top selling date for each merchant' do
+        expect(@merchant1.top_invoice).to eq(@invoice1)
+        expect(@merchant1.top_invoice.format_date).to eq("2023-01-01")
+
       end
     end
   end


### PR DESCRIPTION
Admin Merchants: Top Merchant's Best Day

As an admin,
When I visit the admin merchants index
Then next to each of the 5 merchants by revenue I see the date with the most revenue for each merchant.
And I see a label “Top selling date for <merchant name> was <date with most sales>"

Note: use the invoice date. If there are multiple days with equal number of sales, return the most recent day.